### PR TITLE
Dumper & Additional Patching Methods

### DIFF
--- a/CDK.cpp
+++ b/CDK.cpp
@@ -470,6 +470,46 @@ namespace PlayStation2
 
     ///---------------------------------------------------------------------------------------------------
     //	[MEMORY]
+    bool PS2Memory::WordPatchEE(const __int32& offset, const std::vector<unsigned __int32>& words)
+    {
+		if (offset <= 0 || words.empty())
+			return false;
+
+		const __int64 pAddr = GetEEAddr(offset);
+
+		for (size_t i = 0; i < words.size(); i++)
+		{
+            PS2Memory::WriteLong<__int32>(pAddr + (i * 4), words[i]);
+			if (PS2Memory::ReadLong<__int32>(pAddr + (i * 4)) != words[i])
+				return false;
+		}
+
+
+        return true;
+    }
+
+    ///---------------------------------------------------------------------------------------------------
+    //	[MEMORY]
+    bool PS2Memory::WordNopEE(const __int32& offset, const size_t& words)
+    {
+
+        if (offset <= 0 || words == 0)
+            return false;
+
+        const __int64 pAddr = GetEEAddr(offset);
+
+        for (size_t i = 0; i < words; i++)
+        {
+            PS2Memory::WriteLong<__int32>(pAddr + (i * 4), 0);
+            if (PS2Memory::ReadLong<__int32>(pAddr + (i * 4)) != 0)
+                return false;
+        }
+
+        return true;
+    }
+
+    ///---------------------------------------------------------------------------------------------------
+    //	[MEMORY]
 	// Get executable space in EE memory ( finds the first space matching criteria , often not the best way of doing it )
     __int64 PS2Memory::FindExecCodeBlock(const DWORD& szDetour)
     {

--- a/CDK.h
+++ b/CDK.h
@@ -763,6 +763,8 @@ namespace PlayStation2
         static __int64                  GetEEAddr(__int32 offset);          //  transform offset to virtual address. 0x44D648 -> 00007FF6C44D648      
 		static __int64					GetScratchAddr(__int32 offset);		//  transform scratchpad offset to virtual address. 0x1F00 -> 00007FF6C801F00
 		static __int64                  ResolvePtrChain(__int32 base_offset, std::vector<__int32> offsets); //  resolves a pointer chain to a final address
+		static bool 				    WordPatchEE(const __int32& offset, const std::vector<unsigned __int32>& words); //	Patch a section of EE memory with size bytes from the bytes array
+		static bool						WordNopEE(const __int32& offset, const size_t& size);	//	NOP a section of EE memory with size bytes
 		static __int64					FindExecCodeBlock(const DWORD& szDetour);	// Get executable space in EE memory ( finds the first space matching criteria , often not the best way of doing it )
 		static bool 					DumpSectionToFile(const char* filename, const __int64& start_offset, const size_t& size); // Dumps a section of memory to a file
 		static bool 					DumpEEToFile(const char* filename); // Dumps the entire EE memory to a file

--- a/CDK.h
+++ b/CDK.h
@@ -764,6 +764,8 @@ namespace PlayStation2
 		static __int64					GetScratchAddr(__int32 offset);		//  transform scratchpad offset to virtual address. 0x1F00 -> 00007FF6C801F00
 		static __int64                  ResolvePtrChain(__int32 base_offset, std::vector<__int32> offsets); //  resolves a pointer chain to a final address
 		static __int64					FindExecCodeBlock(const DWORD& szDetour);	// Get executable space in EE memory ( finds the first space matching criteria , often not the best way of doing it )
+		static bool 					DumpSectionToFile(const char* filename, const __int64& start_offset, const size_t& size); // Dumps a section of memory to a file
+		static bool 					DumpEEToFile(const char* filename); // Dumps the entire EE memory to a file
 	};
 
 	/* helper methods */


### PR DESCRIPTION
This pull request adds new utility functions to the `PS2Memory` class in the PlayStation 2 emulator codebase, enhancing its ability to patch, NOP, and dump sections of EE (Emotion Engine) memory. These changes improve the flexibility for memory manipulation and debugging.

**Memory patching and manipulation:**

* Added `WordPatchEE`, which patches a section of EE memory with a vector of 32-bit words and verifies the write. (`CDK.cpp`, `CDK.h`) [[1]](diffhunk://#diff-c9422952735c14f33961f4ceebe7d4c1ee8425fe53204327144dcc27a4dfe401R471-R510) [[2]](diffhunk://#diff-b8e1b15634ae4e82e477c96645c866b4e307b15fdf94e3dcee93d215ad8e9b8aR766-R770)
* Added `WordNopEE`, which fills a section of EE memory with NOPs (zeroes) for a specified number of words, verifying the operation. (`CDK.cpp`, `CDK.h`) [[1]](diffhunk://#diff-c9422952735c14f33961f4ceebe7d4c1ee8425fe53204327144dcc27a4dfe401R471-R510) [[2]](diffhunk://#diff-b8e1b15634ae4e82e477c96645c866b4e307b15fdf94e3dcee93d215ad8e9b8aR766-R770)

**Memory dumping utilities:**

* Added `DumpSectionToFile`, allowing any section of EE memory to be dumped to a file, with chunked reading for efficiency. (`CDK.cpp`, `CDK.h`) [[1]](diffhunk://#diff-c9422952735c14f33961f4ceebe7d4c1ee8425fe53204327144dcc27a4dfe401R539-R585) [[2]](diffhunk://#diff-b8e1b15634ae4e82e477c96645c866b4e307b15fdf94e3dcee93d215ad8e9b8aR766-R770)
* Added `DumpEEToFile`, which dumps the entire EE memory region to a file for debugging or analysis. (`CDK.cpp`, `CDK.h`) [[1]](diffhunk://#diff-c9422952735c14f33961f4ceebe7d4c1ee8425fe53204327144dcc27a4dfe401R539-R585) [[2]](diffhunk://#diff-b8e1b15634ae4e82e477c96645c866b4e307b15fdf94e3dcee93d215ad8e9b8aR766-R770)